### PR TITLE
Fix Strava JSON parse failure for users with many activities

### DIFF
--- a/firmware/IBIS_V40.ino
+++ b/firmware/IBIS_V40.ino
@@ -1145,7 +1145,7 @@ void fetchStravaData() {
     HTTPClient http;
     String req = "https://www.strava.com/api/v3/athlete/activities?";
     req += "after=" + String(afterTS) + "&before=" + String(beforeTS);
-    req += "&per_page=200&page=" + String(page);
+    req += "&per_page=30&page=" + String(page);
     
     http.begin(req);
     http.addHeader("Authorization", "Bearer " + accessToken);
@@ -1160,9 +1160,19 @@ void fetchStravaData() {
     }
     
     String payload = http.getString();
+
+    // Only parse the fields we need — drastically reduces memory usage
+    JsonDocument filter;
+    filter[0]["type"] = true;
+    filter[0]["name"] = true;
+    filter[0]["start_date_local"] = true;
+    filter[0]["distance"] = true;
+    filter[0]["moving_time"] = true;
+    filter[0]["map"]["summary_polyline"] = true;
+
     JsonDocument doc;
-    
-    if (deserializeJson(doc, payload)) {
+
+    if (deserializeJson(doc, payload, DeserializationOption::Filter(filter))) {
       USBSerial.println("JSON parse error");
       http.end();
       break;


### PR DESCRIPTION
## Summary

Two changes to fix Strava data not loading for users with many activities:

- **Reduce `per_page` from 200 to 30** — smaller JSON responses per request
- **Add `DeserializationOption::Filter`** — only parse the 6 fields actually used (`type`, `name`, `start_date_local`, `distance`, `moving_time`, `map.summary_polyline`)

With 200 activities per page, the JSON response can exceed available ESP32-S3 heap memory, causing `deserializeJson()` to fail. This results in all dashboard stats showing 0. The filter alone would likely fix it, but smaller pages add a safety margin.

Pagination still works correctly — 30 per page × 10 max pages = 300 activities per tracking period.

## How I found it

Setting up Ibis Dash for a Strava account with 1,400+ rides. Serial monitor showed `JSON parse error` on every fetch attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)